### PR TITLE
fix：Notion API 变更紧急更新

### DIFF
--- a/components/NotionPage.js
+++ b/components/NotionPage.js
@@ -116,6 +116,10 @@ const NotionPage = ({ post, className }) => {
     return () => clearTimeout(timer)
   }, [post])
 
+  if (!post?.blockMap) {
+    return null
+  }
+
   return (
     <div
       id='notion-article'

--- a/lib/notion/getPostBlocks.js
+++ b/lib/notion/getPostBlocks.js
@@ -8,6 +8,35 @@ import { deepClone, delay } from '../utils'
 import notionAPI from '@/lib/notion/getNotionAPI'
 
 /**
+ * 标准化Notion API返回的recordMap数据结构
+ * Notion API近期变更，部分block/collection返回了多一层嵌套:
+ *   旧结构: { value: { id, type, ... }, role: "reader" }
+ *   新结构: { spaceId: "...", value: { value: { id, type, ... }, role: "reader" } }
+ * 此函数将新结构统一转换为旧结构，确保下游代码兼容
+ */
+function normalizeRecordMap(recordMap) {
+  if (!recordMap) return recordMap
+
+  const recordTypes = ['block', 'collection', 'collection_view']
+  for (const type of recordTypes) {
+    const records = recordMap[type]
+    if (!records) continue
+
+    for (const id of Object.keys(records)) {
+      const record = records[id]
+      if (record?.spaceId && record?.value?.value) {
+        records[id] = {
+          value: record.value.value,
+          role: record.value.role
+        }
+      }
+    }
+  }
+
+  return recordMap
+}
+
+/**
  * 获取文章内容块
  * @param {*} id
  * @param {*} from
@@ -45,8 +74,10 @@ export async function getPage(id, from = null, slice) {
  * @param {*} retryAttempts
  */
 export async function getPageWithRetry(id, from, retryAttempts = 3) {
-  // 校验id必须是有效的字符串（Notion页面ID）
-  if (!id || typeof id !== 'string' || id.length < 10) {
+  // 校验id必须是有效的Notion页面ID（32位十六进制，可含连字符）
+  const isValidNotionId = id && typeof id === 'string' &&
+    /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(id.trim())
+  if (!isValidNotionId) {
     console.warn('[API] 无效的页面ID，跳过请求:', id)
     return null
   }
@@ -62,7 +93,7 @@ export async function getPageWithRetry(id, from, retryAttempts = 3) {
       const pageData = await notionAPI.getPage(id)
       const end = new Date().getTime()
       console.log('[API<<--响应]', `耗时:${end - start}ms - from:${from}`)
-      return pageData
+      return normalizeRecordMap(pageData)
     } catch (e) {
       console.warn('[API<<--异常]:', e)
       await delay(1000)
@@ -187,10 +218,11 @@ export const fetchInBatches = async (ids, batchSize = 100) => {
     )
 
     console.log('[API<<--响应]')
+    const normalizedChunk = normalizeRecordMap(pageChunk?.recordMap)
     fetchedBlocks = Object.assign(
       {},
       fetchedBlocks,
-      pageChunk?.recordMap?.block
+      normalizedChunk?.block
     )
   }
   return fetchedBlocks


### PR DESCRIPTION
## 已知问题
Notion 的 API 最近变更了返回数据的结构。部分 block 和 collection
  的数据多了一层嵌套：
  Column 1: block
  旧结构: { value: { type, id, ... }, role }
  新结构: { spaceId, value: { value: { type, id, ... }, role } }
  你的博客代码读取 block[pageId].value.type 时得到 undefined（因为实际数据在
  block[pageId].value.value.type），导致页面被误判为"不是数据库"，从而返回 EmptyData。

## 解决方案

修复内容（共4个文件）:

  1. lib/notion/getPostBlocks.js — 核心修复：添加 normalizeRecordMap() 函数，在 Notion API 返回数据后自动解包多余的嵌套层，统一为旧格式。同时将 ID 校验从 id.length < 10 改为正则校验合法的 Notion UUID。
  2. components/NotionPage.js — 添加 blockMap 为 null 时的安全保护，避免 NotionRenderer 崩溃。
  3. lib/db/getSiteData.js — EmptyData 的 id 改为字符串，增加 href/pageIcon 字段（之前的修复保留）。
  4. lib/rss.js — 仅在 NOTION_CONFIG 有加密邮箱时才调用 decryptEmail（之前的修复保留）。

  验证结果: 构建成功生成 97 个页面（含真实文章分类/标签），yarn start
  运行无报错，首页正确显示 "Joey's 博客"。

