### PR TITLE
修复总结

### DIFF
--- a/lib/cache/local_file_cache.js
+++ b/lib/cache/local_file_cache.js
@@ -53,10 +53,19 @@ export function delCache(key) {
 
 /**
  * 清理缓存
+ * Vercel/serverless 文件系统只读(EROFS)，文件缓存在生产环境本就不可用，
+ * 写入失败时静默跳过，避免接口 500。
  */
 export function cleanCache() {
-  const json = {}
-  fs.writeFileSync(jsonFile, JSON.stringify(json))
+  try {
+    fs.writeFileSync(jsonFile, JSON.stringify({}))
+  } catch (e) {
+    if (e?.code === 'EROFS' || e?.code === 'EACCES' || e?.code === 'EPERM') {
+      console.warn('[cleanCache] 跳过文件缓存清理（只读文件系统）:', e.code)
+      return
+    }
+    throw e
+  }
 }
 
-export default { getCache, setCache, delCache }
+export default { getCache, setCache, delCache, cleanCache }

--- a/lib/cache/memory_cache.js
+++ b/lib/cache/memory_cache.js
@@ -15,4 +15,8 @@ export async function delCache(key) {
   await cache.del(key)
 }
 
-export default { getCache, setCache, delCache }
+export async function cleanCache() {
+  cache.clear()
+}
+
+export default { getCache, setCache, delCache, cleanCache }

--- a/lib/cache/redis_cache.js
+++ b/lib/cache/redis_cache.js
@@ -38,4 +38,14 @@ export async function delCache(key) {
   }
 }
 
-export default { getCache, setCache, delCache }
+export async function cleanCache() {
+  try {
+    if (typeof redisClient.flushdb === 'function') {
+      await redisClient.flushdb()
+    }
+  } catch (e) {
+    console.error(`redisClient清理失败 ${String(e)}`)
+  }
+}
+
+export default { getCache, setCache, delCache, cleanCache }

--- a/pages/api/cache.js
+++ b/pages/api/cache.js
@@ -1,15 +1,28 @@
-import { cleanCache } from '@/lib/cache/local_file_cache'
+import { getApi } from '@/lib/cache/cache_manager'
 
 /**
  * 清理缓存
+ * 通过 getApi() 选择当前实际生效的缓存后端（生产为 MemoryCache），
+ * 而非写死文件缓存，避免在 Vercel 只读文件系统上报 EROFS。
+ * 注意：serverless 下 MemoryCache 为单实例内存，只能清理处理本次请求的实例，
+ * 让内容变更（如 noindex 配置）真正上线需重新部署，而非调用本接口。
  * @param {*} req
  * @param {*} res
  */
 export default async function handler(req, res) {
   try {
-    await cleanCache()
-    res.status(200).json({ status: 'success', message: 'Clean cache successful!' })
+    const api = getApi()
+    if (typeof api.cleanCache === 'function') {
+      await api.cleanCache()
+    }
+    res
+      .status(200)
+      .json({ status: 'success', message: 'Clean cache successful!' })
   } catch (error) {
-    res.status(400).json({ status: 'error', message: 'Clean cache failed!', error })
+    res.status(400).json({
+      status: 'error',
+      message: 'Clean cache failed!',
+      error: String(error?.message || error)
+    })
   }
 }


### PR DESCRIPTION
改了什么
- pages/api/cache.js：改走 getApi()，清理当前实际生效的后端（生产是 MemoryCache），不再写死文件缓存。
- lib/cache/local_file_cache.js：cleanCache 捕获 EROFS/EACCES/EPERM，只读文件系统下静默跳过，不再抛错。
- lib/cache/memory_cache.js / redis_cache.js：各补一个 cleanCache（cache.clear() / flushdb()）并加入默认导出。

部署后再访问 /api/cache 会返回 success，不会再报 EROFS。

但请注意（直接回答你「这是没
                                                                          这个接口报错和 noindex 没生效dex 生效。
                                                                          - noindex 清单是编译进构建的
- 文章页是 Next.js ISR 缓存（revalidate 24h），不归这个接口管。           - serverless 下 MemoryCache是单实例内存、冷启动即清空，这个接口最多清掉「处理这次请求的那一个 lambda 实例」，对其它实例无效——所以  线」也基本没用。

要让 noindex（以及之前那两个 是：重新部署。 部署完用 GSC的「网址检查 → 请求编入索引」促使 Google 重爬看到 noindex 标签。

> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. (示例)版本号管理不规范
   - 版本号直接写在环境变量中，容易出错
   - 多处维护版本号，可能不一致

## 解决方案

1. (示例)将版本号管理从 `.env.local` 迁移到 `package.json`
   - 统一从 `package.json` 读取版本号
   - 使用 IIFE 优雅处理版本号获取逻辑
   - 保持向后兼容，支持环境变量覆盖

## 改动收益

1. (示例)更规范的版本管理
   - 统一从 `package.json` 读取
   - 保持与 npm 生态一致
   - 减少人为错误

## 具体改动

1. （示例）`blog.config.js`
   - 移除原有的静态版本号配置
   - 在文件末尾添加动态版本号获取逻辑
   - 保持向后兼容，优先使用环境变量
   - 添加错误处理和默认值

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
