### PR TITLE
Refactor getStaticProps in index.js and [slug]/index.js to improve ha…

### DIFF
--- a/pages/[prefix]/[slug]/index.js
+++ b/pages/[prefix]/[slug]/index.js
@@ -69,21 +69,23 @@ export async function getStaticProps({ params: { prefix, slug }, locale }) {
     }
   }
 
+  const revalidate = process.env.EXPORT
+    ? undefined
+    : siteConfig(
+        'NEXT_REVALIDATE_SECOND',
+        BLOG.NEXT_REVALIDATE_SECOND,
+        props.NOTION_CONFIG
+      )
+
   if (!props?.post) {
-    // 无法获取文章
-    props.post = null
-  } else {
-    await processPostData(props, from)
+    // A：找不到文章 → 返回 404，避免「200 空壳 + 可收录」的软 404
+    return { notFound: true, revalidate }
   }
+
+  await processPostData(props, from)
   return {
     props,
-    revalidate: process.env.EXPORT
-      ? undefined
-      : siteConfig(
-          'NEXT_REVALIDATE_SECOND',
-          BLOG.NEXT_REVALIDATE_SECOND,
-          props.NOTION_CONFIG
-        )
+    revalidate
   }
 }
 

--- a/pages/[prefix]/index.js
+++ b/pages/[prefix]/index.js
@@ -135,28 +135,46 @@ export async function getStaticProps({ params: { prefix }, locale }) {
       props.post = post
     }
   }
-  if (!props?.post) {
-    // 无法获取文章
-    props.post = null
-  } else {
-    await processPostData(props, from)
-    // 在服务器端生成目录
-    if (props.post?.blockMap?.block) {
-      props.post.content = Object.keys(props.post.blockMap.block).filter(
-        key => props.post.blockMap.block[key]?.value?.parent_id === props.post.id
+
+  const revalidate = process.env.EXPORT
+    ? undefined
+    : siteConfig(
+        'NEXT_REVALIDATE_SECOND',
+        BLOG.NEXT_REVALIDATE_SECOND,
+        props.NOTION_CONFIG
       )
-      props.post.toc = getPageTableOfContents(props.post, props.post.blockMap)
+
+  if (!props?.post) {
+    // B：无前缀路径若能对应到带前缀的文章（如 /foo → /article/foo），永久重定向到真实地址
+    const canonical = props?.allPages?.find(p => {
+      if (!p?.slug || (p.type || '').indexOf('Menu') >= 0) return false
+      const segments = p.slug.split('/').filter(Boolean)
+      return segments.length === 2 && segments[1] === prefix
+    })
+    if (canonical?.slug) {
+      return {
+        redirect: {
+          destination: `/${canonical.slug}`,
+          permanent: true
+        }
+      }
     }
+    // A：既非有效文章、也无对应前缀文章 → 返回 404，避免「200 空壳 + 可收录」的软 404
+    return { notFound: true, revalidate }
   }
+
+  await processPostData(props, from)
+  // 在服务器端生成目录
+  if (props.post?.blockMap?.block) {
+    props.post.content = Object.keys(props.post.blockMap.block).filter(
+      key => props.post.blockMap.block[key]?.value?.parent_id === props.post.id
+    )
+    props.post.toc = getPageTableOfContents(props.post, props.post.blockMap)
+  }
+
   return {
     props,
-    revalidate: process.env.EXPORT
-      ? undefined
-      : siteConfig(
-          'NEXT_REVALIDATE_SECOND',
-          BLOG.NEXT_REVALIDATE_SECOND,
-          props.NOTION_CONFIG
-        )
+    revalidate
   }
 }
 


### PR DESCRIPTION
A+B 实现完成

pages/[prefix]/index.js（单段路由，A+B）
- B：无前缀路径找不到文章时，在 allPages 里找「某篇两段 slug 的末段 == 当前路径」的文章（如 article/claude-code-token-rtk-89-percent），找到就 308 永久重定向到 /article/<slug>。
- A：既不是有效文章、也没有对应的带前缀文章 → notFound（404），不再返回 200 空壳。

pages/[prefix]/[slug]/index.js（两段路由，A）
- 找不到文章 → 404（之前 /article/<不存在> 也是 200 空壳，一并堵上）。

安全性：两处只在 post 为空时才 404，现有文章（含 [category]/[slug] 形式访问）都能命中 find 不受影响；被 404 的只有原本就空白无意义的路径。404 带 revalidate，日后若新增同名文章会自动恢复。

部署后验证

# B: 无前缀 → 308 跳转到 /article/...
curl -sI https://mufeng.blog/claude-code-token-rtk-89-percent | grep -iE '^(HTTP|location)'
#   期望: HTTP 308 + location: /article/claude-code-token-rtk-89-percent  （你截图那个 URL 就好了）

# A: 垃圾路径 → 404
curl -sI https://mufeng.blog/this-is-junk-xyz123        | grep -i '^HTTP'   # 期望 404
curl -sI https://mufeng.blog| grep -i '^HTTP'  # 期望 404

# 随笔可读 + noindex（解耦后
curl -sI https://mufeng.blog/article/principles-and-risk | grep -i '^HTTP'
            # 期望 200
curl -s  https://mufeng.blog| grep -o '<meta
name="robots"[^>]*>'      #

说明：permanent: true 是 308 重转到 /article/...）。

注意

- 我没有在本地跑 next build  getStaticProps纯逻辑、已逐行核对；最终以部署后上面那几条 curl 为准。
- 这两个文件 + 已提交的 conttion.config.js一起部署后，整条链路才完整生效。