### PR TITLE
Enhance page view tracking by adding new entries for "ios-interactive…

### DIFF
--- a/data/page-views.json
+++ b/data/page-views.json
@@ -114,5 +114,13 @@
   "claude-code-content-workflow-weekly": {
     "count": 1,
     "lastUpdated": "2023-06-16T00:08:59.000Z"
+  },
+  "ios-interactive-pop-gesture-conflict-debugging": {
+    "count": 2,
+    "lastUpdated": "2026-07-01T18:33:41.217Z"
+  },
+  "finish-what-you-start": {
+    "count": 1,
+    "lastUpdated": "2026-07-01T18:34:35.292Z"
   }
 }

--- a/lib/notion/getPageTableOfContents.js
+++ b/lib/notion/getPageTableOfContents.js
@@ -6,6 +6,19 @@ const indentLevels = {
   sub_sub_header: 2
 }
 
+function getHeaderIndentLevel(type) {
+  if (Object.prototype.hasOwnProperty.call(indentLevels, type)) {
+    return indentLevels[type]
+  }
+
+  const match = /^header_(\d+)$/.exec(type)
+  if (match) {
+    return Math.max(0, Number(match[1]) - 1)
+  }
+
+  return null
+}
+
 /**
  * @see https://github.com/NotionX/react-notion-x/blob/master/packages/notion-utils/src/get-page-table-of-contents.ts
  * Gets the metadata for a table of contents block by parsing the page's
@@ -73,13 +86,18 @@ function getBlockHeader(contents, recordMap, toc) {
       getBlockHeader(block.content, recordMap, toc)
     } else {
       if (type && type.indexOf('header') >= 0) {
+        const indentLevel = getHeaderIndentLevel(type)
+        if (indentLevel === null) {
+          continue
+        }
+
         const existed = toc.find(e => e.id === blockId)
         if (!existed) {
           toc.push({
             id: blockId,
             type,
             text: getTextContent(block.properties?.title),
-            indentLevel: indentLevels[type]
+            indentLevel
           })
         }
       } else if (type === 'transclusion_reference') {

--- a/pages/[prefix]/[slug]/[...suffix].js
+++ b/pages/[prefix]/[slug]/[...suffix].js
@@ -1,6 +1,7 @@
 import BLOG from '@/blog.config'
 import { siteConfig } from '@/lib/config'
 import { getGlobalData, getPost } from '@/lib/db/getSiteData'
+import { isLikelyScannerPath } from '@/lib/utils/is-scanner-path'
 import { checkSlugHasMorThanTwoSlash, processPostData } from '@/lib/utils/post'
 import { idToUuid } from 'notion-utils'
 import Slug from '..'
@@ -23,7 +24,7 @@ export async function getStaticPaths() {
   if (!BLOG.isProd) {
     return {
       paths: [],
-      fallback: true
+      fallback: 'blocking'
     }
   }
 
@@ -40,7 +41,7 @@ export async function getStaticPaths() {
     }))
   return {
     paths: paths,
-    fallback: true
+    fallback: 'blocking'
   }
 }
 
@@ -53,7 +54,22 @@ export async function getStaticProps({
   params: { prefix, slug, suffix },
   locale
 }) {
-  const fullSlug = prefix + '/' + slug + '/' + suffix.join('/')
+  const suffixSegments = Array.isArray(suffix) ? suffix : [suffix]
+  const pathSegments = [prefix, slug, ...suffixSegments]
+
+  if (
+    pathSegments.some(
+      segment =>
+        !segment || segment === 'undefined' || isLikelyScannerPath(segment)
+    )
+  ) {
+    return { notFound: true }
+  }
+
+  const suffixPath = suffixSegments.join('/')
+  const tailSlug = slug + '/' + suffixPath
+  const lastSlugSegment = suffixSegments[suffixSegments.length - 1]
+  const fullSlug = prefix + '/' + tailSlug
   const from = `slug-props-${fullSlug}`
   const props = await getGlobalData({ from, locale })
 
@@ -61,8 +77,9 @@ export async function getStaticProps({
   props.post = props?.allPages?.find(p => {
     return (
       (p.type || '').indexOf('Menu') < 0 &&
-      (p.slug === suffix ||
-        p.slug === fullSlug.substring(fullSlug.lastIndexOf('/') + 1) ||
+      (p.slug === tailSlug ||
+        p.slug === suffixPath ||
+        p.slug === lastSlugSegment ||
         p.slug === fullSlug ||
         p.id === idToUuid(fullSlug))
     )
@@ -78,11 +95,11 @@ export async function getStaticProps({
   }
 
   if (!props?.post) {
-    // 无法获取文章
-    props.post = null
-  } else {
-    await processPostData(props, from)
+    // 找不到文章时返回真正的 404，避免 fallback 空壳页面被当作正常文章。
+    return { notFound: true }
   }
+
+  await processPostData(props, from)
   return {
     props,
     revalidate: process.env.EXPORT

--- a/public/content-quality-report.json
+++ b/public/content-quality-report.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-06-25T11:27:07.539Z",
-  "site": "https://preview.tangly1024.com",
+  "generatedAt": "2026-07-01T18:33:21.909Z",
+  "site": "https://mufeng.blog",
   "qualityGuard": {
     "enabled": true,
     "minSummaryChars": 80,
@@ -16,28 +16,25 @@
     ]
   },
   "totals": {
-    "publishedPosts": 12,
-    "lowQualityPosts": 8,
-    "indexBlockedPosts": 5,
-    "warningOnlyPosts": 3
+    "publishedPosts": 186,
+    "lowQualityPosts": 29,
+    "indexBlockedPosts": 0,
+    "warningOnlyPosts": 29
   },
   "reasonStats": {
     "all": {
-      "short-summary": 7,
-      "duplicate-title": 5
+      "short-summary": 29
     },
-    "blocking": {
-      "duplicate-title": 5
-    },
+    "blocking": {},
     "warning": {
-      "short-summary": 3
+      "short-summary": 29
     }
   },
   "lowQualityPosts": [
     {
-      "id": "6f414124-3a8f-4878-b07e-5d1a9fcdd703",
-      "slug": "article/example-2",
-      "title": "Locked article - Password: 123456",
+      "id": "35eb2da8-94ba-80f2-a983-d9259e2f2287",
+      "slug": "article/agent-skills-ai-memory-handbook",
+      "title": "AI 每天早上都失忆了，直到我给它装了这",
       "isIndexBlocked": false,
       "reasons": [
         "short-summary"
@@ -46,17 +43,17 @@
       "warningReasons": [
         "short-summary"
       ],
-      "summaryChars": 60,
+      "summaryChars": 74,
       "wordCount": 0,
-      "publishDay": "2021-11-5",
-      "lastEditedDay": "2024-4-8",
-      "href": "/article/example-2",
-      "url": "https://preview.tangly1024.com/article/example-2"
+      "publishDay": "2026-5-12",
+      "lastEditedDay": "2026-5-12",
+      "href": "/article/agent-skills-ai-memory-handbook",
+      "url": "https://mufeng.blog/article/agent-skills-ai-memory-handbook"
     },
     {
-      "id": "56cce11d-2347-4ae6-b8e4-a382b3cbf844",
-      "slug": "article/example-3",
-      "title": "EMPTY-ARTICLE",
+      "id": "350b2da8-94ba-8043-a147-e1e7ac78710f",
+      "slug": "article/app-store-launch-lessons-indie-ios-developer",
+      "title": "一个 iOS 独立开发者的 App Store 上线复盘",
       "isIndexBlocked": false,
       "reasons": [
         "short-summary"
@@ -65,124 +62,17 @@
       "warningReasons": [
         "short-summary"
       ],
-      "summaryChars": 46,
+      "summaryChars": 77,
       "wordCount": 0,
-      "publishDay": "2021-7-2",
-      "lastEditedDay": "2024-4-8",
-      "href": "/article/example-3",
-      "url": "https://preview.tangly1024.com/article/example-3"
+      "publishDay": "2026-4-28",
+      "lastEditedDay": "2026-4-28",
+      "href": "/article/app-store-launch-lessons-indie-ios-developer",
+      "url": "https://mufeng.blog/article/app-store-launch-lessons-indie-ios-developer"
     },
     {
-      "id": "57cb9b33-db50-4b6f-a363-d9f2c6b84654",
-      "slug": "article/example-5",
-      "title": "Blank article",
-      "isIndexBlocked": true,
-      "reasons": [
-        "duplicate-title"
-      ],
-      "blockingReasons": [
-        "duplicate-title"
-      ],
-      "warningReasons": [],
-      "summaryChars": 230,
-      "wordCount": 0,
-      "publishDay": "2021-7-2",
-      "lastEditedDay": "2024-4-8",
-      "href": "/article/example-5",
-      "url": "https://preview.tangly1024.com/article/example-5"
-    },
-    {
-      "id": "54259497-8c1c-49a9-ae4c-ea970f375250",
-      "slug": "article/example-6",
-      "title": "Blank article",
-      "isIndexBlocked": true,
-      "reasons": [
-        "short-summary",
-        "duplicate-title"
-      ],
-      "blockingReasons": [
-        "duplicate-title"
-      ],
-      "warningReasons": [
-        "short-summary"
-      ],
-      "summaryChars": 46,
-      "wordCount": 0,
-      "publishDay": "2021-7-2",
-      "lastEditedDay": "2024-4-8",
-      "href": "/article/example-6",
-      "url": "https://preview.tangly1024.com/article/example-6"
-    },
-    {
-      "id": "5ac82b42-0726-4f5a-9cff-b7b3000f5879",
-      "slug": "article/example-7",
-      "title": "Blank article",
-      "isIndexBlocked": true,
-      "reasons": [
-        "short-summary",
-        "duplicate-title"
-      ],
-      "blockingReasons": [
-        "duplicate-title"
-      ],
-      "warningReasons": [
-        "short-summary"
-      ],
-      "summaryChars": 46,
-      "wordCount": 0,
-      "publishDay": "2021-7-2",
-      "lastEditedDay": "2024-4-8",
-      "href": "/article/example-7",
-      "url": "https://preview.tangly1024.com/article/example-7"
-    },
-    {
-      "id": "38d1cb35-dfab-41d6-9620-66360108890d",
-      "slug": "article/example-8",
-      "title": "Blank article",
-      "isIndexBlocked": true,
-      "reasons": [
-        "short-summary",
-        "duplicate-title"
-      ],
-      "blockingReasons": [
-        "duplicate-title"
-      ],
-      "warningReasons": [
-        "short-summary"
-      ],
-      "summaryChars": 46,
-      "wordCount": 0,
-      "publishDay": "2021-7-2",
-      "lastEditedDay": "2024-4-8",
-      "href": "/article/example-8",
-      "url": "https://preview.tangly1024.com/article/example-8"
-    },
-    {
-      "id": "c4fe8170-c1be-4ed8-a3e5-680d2fa189d6",
-      "slug": "article/example-9",
-      "title": "Blank article",
-      "isIndexBlocked": true,
-      "reasons": [
-        "short-summary",
-        "duplicate-title"
-      ],
-      "blockingReasons": [
-        "duplicate-title"
-      ],
-      "warningReasons": [
-        "short-summary"
-      ],
-      "summaryChars": 46,
-      "wordCount": 0,
-      "publishDay": "2021-7-2",
-      "lastEditedDay": "2024-4-8",
-      "href": "/article/example-9",
-      "url": "https://preview.tangly1024.com/article/example-9"
-    },
-    {
-      "id": "f6656d78-c801-40f3-9815-cd47a77a0f52",
-      "slug": "article/f6656d78-c801-40f3-9815-cd47a77a0f52",
-      "title": "",
+      "id": "34ab2da8-94ba-809f-aa17-d94f9b83cf2c",
+      "slug": "article/codex-npm-optional-dependencies-question",
+      "title": "Codex CLI 安装踩坑实录：npm optionalDependencies 问题 & pnpm 终极解决方案",
       "isIndexBlocked": false,
       "reasons": [
         "short-summary"
@@ -191,121 +81,507 @@
       "warningReasons": [
         "short-summary"
       ],
-      "summaryChars": 15,
+      "summaryChars": 73,
       "wordCount": 0,
-      "publishDay": "2021-7-2",
-      "lastEditedDay": "2024-6-4",
-      "href": "/article/f6656d78-c801-40f3-9815-cd47a77a0f52",
-      "url": "https://preview.tangly1024.com/article/f6656d78-c801-40f3-9815-cd47a77a0f52"
+      "publishDay": "2026-4-22",
+      "lastEditedDay": "2026-6-7",
+      "href": "/article/codex-npm-optional-dependencies-question",
+      "url": "https://mufeng.blog/article/codex-npm-optional-dependencies-question"
+    },
+    {
+      "id": "349b2da8-94ba-802b-a42b-ded22ceb7518",
+      "slug": "article/notebooklm-learning-case-study",
+      "title": "我用 NotebookLM，完整复盘一个真实学习案例",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 78,
+      "wordCount": 0,
+      "publishDay": "2026-4-21",
+      "lastEditedDay": "2026-4-21",
+      "href": "/article/notebooklm-learning-case-study",
+      "url": "https://mufeng.blog/article/notebooklm-learning-case-study"
+    },
+    {
+      "id": "349b2da8-94ba-80ee-b063-e13e79cbffbf",
+      "slug": "article/ai-for-solo-ios-developers",
+      "title": "AI 让我不再需要团队开发 App",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 47,
+      "wordCount": 0,
+      "publishDay": "2026-4-21",
+      "lastEditedDay": "2026-4-21",
+      "href": "/article/ai-for-solo-ios-developers",
+      "url": "https://mufeng.blog/article/ai-for-solo-ios-developers"
+    },
+    {
+      "id": "33fb2da8-94ba-8068-bfeb-de6d9cc33b29",
+      "slug": "article/stock-analysis-baba",
+      "title": "阿里巴巴（BABA）深度投资分析：AI 转型期的深度价值困境反转",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 79,
+      "wordCount": 0,
+      "publishDay": "2026-4-11",
+      "lastEditedDay": "2026-4-11",
+      "href": "/article/stock-analysis-baba",
+      "url": "https://mufeng.blog/article/stock-analysis-baba"
+    },
+    {
+      "id": "2f2b2da8-94ba-80f2-b7f0-e32e0aef7921",
+      "slug": "article/after-a-small-drink-in-shanghai",
+      "title": "沪上小酌后",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 77,
+      "wordCount": 0,
+      "publishDay": "2026-1-24",
+      "lastEditedDay": "2026-5-26",
+      "href": "/article/after-a-small-drink-in-shanghai",
+      "url": "https://mufeng.blog/article/after-a-small-drink-in-shanghai"
+    },
+    {
+      "id": "1bfb2da8-94ba-801d-b29b-f86ce0d9309a",
+      "slug": "article/build-your-own-digital-home",
+      "title": "为什么我要打造自己的独立博客，而不是依赖第三方平台？",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 13,
+      "wordCount": 0,
+      "publishDay": "2025-3-23",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/build-your-own-digital-home",
+      "url": "https://mufeng.blog/article/build-your-own-digital-home"
+    },
+    {
+      "id": "1c1b2da8-94ba-8054-83fb-cd9148b8764c",
+      "slug": "article/why-index-funds-make-sense",
+      "title": "普通人如何通过价值投资实现财富增长？",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 23,
+      "wordCount": 0,
+      "publishDay": "2025-3-16",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/why-index-funds-make-sense",
+      "url": "https://mufeng.blog/article/why-index-funds-make-sense"
+    },
+    {
+      "id": "1c1b2da8-94ba-80b2-b61f-dbd58fb84458",
+      "slug": "article/some-artists-grow-with-age",
+      "title": "刀郎：用音乐普度众生，用岁月成就经典",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 18,
+      "wordCount": 0,
+      "publishDay": "2025-3-8",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/some-artists-grow-with-age",
+      "url": "https://mufeng.blog/article/some-artists-grow-with-age"
+    },
+    {
+      "id": "1c1b2da8-94ba-80de-a28f-f6654e8b19b2",
+      "slug": "article/build-yourself-into-someone-strong",
+      "title": "工作、学习、财务与成长的一些思考",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 12,
+      "wordCount": 0,
+      "publishDay": "2025-3-2",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/build-yourself-into-someone-strong",
+      "url": "https://mufeng.blog/article/build-yourself-into-someone-strong"
+    },
+    {
+      "id": "1c4b2da8-94ba-8004-b4e1-de4ac7463946",
+      "slug": "article/you-are-creating-yourself",
+      "title": "情绪就是你的风水",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 69,
+      "wordCount": 0,
+      "publishDay": "2025-2-26",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/you-are-creating-yourself",
+      "url": "https://mufeng.blog/article/you-are-creating-yourself"
+    },
+    {
+      "id": "1c4b2da8-94ba-80bc-8490-d3491f4fc2bb",
+      "slug": "article/greatness-takes-time",
+      "title": "《茅台传》读后感：品质是信仰，成功是坚持",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 11,
+      "wordCount": 0,
+      "publishDay": "2025-2-22",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/greatness-takes-time",
+      "url": "https://mufeng.blog/article/greatness-takes-time"
+    },
+    {
+      "id": "1bdb2da8-94ba-8017-8a89-dae5dd7702bd",
+      "slug": "article/nobody-wants-to-get-rich-slowly",
+      "title": "耐心是投资的关键：我的股市定投经验与心得",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 21,
+      "wordCount": 0,
+      "publishDay": "2025-2-15",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/nobody-wants-to-get-rich-slowly",
+      "url": "https://mufeng.blog/article/nobody-wants-to-get-rich-slowly"
+    },
+    {
+      "id": "1c4b2da8-94ba-80be-9d52-e6bfb9f21df4",
+      "slug": "article/investing-is-like-fishing",
+      "title": "放长线钓大鱼",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 23,
+      "wordCount": 0,
+      "publishDay": "2025-2-6",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/investing-is-like-fishing",
+      "url": "https://mufeng.blog/article/investing-is-like-fishing"
+    },
+    {
+      "id": "1c4b2da8-94ba-80b8-b709-c8903d268236",
+      "slug": "article/people-like-me-keep-moving",
+      "title": "过年见闻录",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 12,
+      "wordCount": 0,
+      "publishDay": "2025-2-4",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/people-like-me-keep-moving",
+      "url": "https://mufeng.blog/article/people-like-me-keep-moving"
+    },
+    {
+      "id": "1c5b2da8-94ba-806c-a64c-f0925bbdfff5",
+      "slug": "article/build-your-own-thinking-system",
+      "title": "两个做事实用方法",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 21,
+      "wordCount": 0,
+      "publishDay": "2025-1-20",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/build-your-own-thinking-system",
+      "url": "https://mufeng.blog/article/build-your-own-thinking-system"
+    },
+    {
+      "id": "1c5b2da8-94ba-80a7-baa6-e225b2060d39",
+      "slug": "article/my-first-step-toward-globalization",
+      "title": "建议你有张美金储蓄卡",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 17,
+      "wordCount": 0,
+      "publishDay": "2025-1-17",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/my-first-step-toward-globalization",
+      "url": "https://mufeng.blog/article/my-first-step-toward-globalization"
+    },
+    {
+      "id": "1c5b2da8-94ba-80cd-b2d8-d78bb6fde8d9",
+      "slug": "article/focus-on-your-main-quest",
+      "title": "每天变得更聪明一点点",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 47,
+      "wordCount": 0,
+      "publishDay": "2025-3-29",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/focus-on-your-main-quest",
+      "url": "https://mufeng.blog/article/focus-on-your-main-quest"
+    },
+    {
+      "id": "1c5b2da8-94ba-809b-99b0-c7bedcb2a093",
+      "slug": "article/the-most-important-3-hours",
+      "title": "时间的艺术与财富的哲学",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 75,
+      "wordCount": 0,
+      "publishDay": "2025-1-8",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/the-most-important-3-hours",
+      "url": "https://mufeng.blog/article/the-most-important-3-hours"
+    },
+    {
+      "id": "1c5b2da8-94ba-80e3-9ef2-df248134ae6a",
+      "slug": "article/lessons-from-xiaomi-and-lei-jun",
+      "title": "向雷军学习 - 读《小米创业思考》有感",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 13,
+      "wordCount": 0,
+      "publishDay": "2025-3-29",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/lessons-from-xiaomi-and-lei-jun",
+      "url": "https://mufeng.blog/article/lessons-from-xiaomi-and-lei-jun"
+    },
+    {
+      "id": "1c5b2da8-94ba-8047-b216-da3e4fd8c76b",
+      "slug": "article/run-yourself-like-a-company",
+      "title": "2024年终总结",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 14,
+      "wordCount": 0,
+      "publishDay": "2025-1-1",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/run-yourself-like-a-company",
+      "url": "https://mufeng.blog/article/run-yourself-like-a-company"
+    },
+    {
+      "id": "1cab2da8-94ba-801a-a10c-fa589b2835c9",
+      "slug": "article/busy-but-going-nowhere",
+      "title": "忙碌的误区在于无效的努力",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 58,
+      "wordCount": 0,
+      "publishDay": "2024-12-25",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/busy-but-going-nowhere",
+      "url": "https://mufeng.blog/article/busy-but-going-nowhere"
+    },
+    {
+      "id": "1cab2da8-94ba-80ec-a8e4-d3d87da057f7",
+      "slug": "article/hong-kong-trip-hsbc-card-travel-notes",
+      "title": "深圳、香港二日",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 36,
+      "wordCount": 0,
+      "publishDay": "2025-1-21",
+      "lastEditedDay": "2026-5-23",
+      "href": "/article/hong-kong-trip-hsbc-card-travel-notes",
+      "url": "https://mufeng.blog/article/hong-kong-trip-hsbc-card-travel-notes"
+    },
+    {
+      "id": "1cab2da8-94ba-8070-b518-e021cc52ab9b",
+      "slug": "article/thinking-in-decades",
+      "title": "选择比努力更重要",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 34,
+      "wordCount": 0,
+      "publishDay": "2024-11-16",
+      "lastEditedDay": "2026-5-21",
+      "href": "/article/thinking-in-decades",
+      "url": "https://mufeng.blog/article/thinking-in-decades"
+    },
+    {
+      "id": "1cab2da8-94ba-80f2-a631-ca5fa87ad75c",
+      "slug": "article/upgrading-the-workflow",
+      "title": "利用工具提高效率，珍惜时间",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 33,
+      "wordCount": 0,
+      "publishDay": "2024-11-10",
+      "lastEditedDay": "2026-5-21",
+      "href": "/article/upgrading-the-workflow",
+      "url": "https://mufeng.blog/article/upgrading-the-workflow"
+    },
+    {
+      "id": "1cdb2da8-94ba-80d2-8272-f0f02b78ea50",
+      "slug": "article/mountains-clouds-and-time",
+      "title": "巴山蜀水峨眉山",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 41,
+      "wordCount": 0,
+      "publishDay": "2024-10-2",
+      "lastEditedDay": "2026-5-21",
+      "href": "/article/mountains-clouds-and-time",
+      "url": "https://mufeng.blog/article/mountains-clouds-and-time"
+    },
+    {
+      "id": "1cdb2da8-94ba-800b-a501-ee9f41bedf3a",
+      "slug": "article/principles-and-risk",
+      "title": "瑞·达利欧的五大交易原则",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 24,
+      "wordCount": 0,
+      "publishDay": "2024-7-5",
+      "lastEditedDay": "2026-5-21",
+      "href": "/article/principles-and-risk",
+      "url": "https://mufeng.blog/article/principles-and-risk"
+    },
+    {
+      "id": "1d4b2da8-94ba-805c-b6a7-c9da2e089d3c",
+      "slug": "article/learning-methods-and-quiet-growth",
+      "title": "万般劫难，“静”可保命",
+      "isIndexBlocked": false,
+      "reasons": [
+        "short-summary"
+      ],
+      "blockingReasons": [],
+      "warningReasons": [
+        "short-summary"
+      ],
+      "summaryChars": 32,
+      "wordCount": 0,
+      "publishDay": "2024-3-23",
+      "lastEditedDay": "2026-5-21",
+      "href": "/article/learning-methods-and-quiet-growth",
+      "url": "https://mufeng.blog/article/learning-methods-and-quiet-growth"
     }
   ],
-  "indexBlockedPosts": [
-    {
-      "id": "57cb9b33-db50-4b6f-a363-d9f2c6b84654",
-      "slug": "article/example-5",
-      "title": "Blank article",
-      "isIndexBlocked": true,
-      "reasons": [
-        "duplicate-title"
-      ],
-      "blockingReasons": [
-        "duplicate-title"
-      ],
-      "warningReasons": [],
-      "summaryChars": 230,
-      "wordCount": 0,
-      "publishDay": "2021-7-2",
-      "lastEditedDay": "2024-4-8",
-      "href": "/article/example-5",
-      "url": "https://preview.tangly1024.com/article/example-5"
-    },
-    {
-      "id": "54259497-8c1c-49a9-ae4c-ea970f375250",
-      "slug": "article/example-6",
-      "title": "Blank article",
-      "isIndexBlocked": true,
-      "reasons": [
-        "short-summary",
-        "duplicate-title"
-      ],
-      "blockingReasons": [
-        "duplicate-title"
-      ],
-      "warningReasons": [
-        "short-summary"
-      ],
-      "summaryChars": 46,
-      "wordCount": 0,
-      "publishDay": "2021-7-2",
-      "lastEditedDay": "2024-4-8",
-      "href": "/article/example-6",
-      "url": "https://preview.tangly1024.com/article/example-6"
-    },
-    {
-      "id": "5ac82b42-0726-4f5a-9cff-b7b3000f5879",
-      "slug": "article/example-7",
-      "title": "Blank article",
-      "isIndexBlocked": true,
-      "reasons": [
-        "short-summary",
-        "duplicate-title"
-      ],
-      "blockingReasons": [
-        "duplicate-title"
-      ],
-      "warningReasons": [
-        "short-summary"
-      ],
-      "summaryChars": 46,
-      "wordCount": 0,
-      "publishDay": "2021-7-2",
-      "lastEditedDay": "2024-4-8",
-      "href": "/article/example-7",
-      "url": "https://preview.tangly1024.com/article/example-7"
-    },
-    {
-      "id": "38d1cb35-dfab-41d6-9620-66360108890d",
-      "slug": "article/example-8",
-      "title": "Blank article",
-      "isIndexBlocked": true,
-      "reasons": [
-        "short-summary",
-        "duplicate-title"
-      ],
-      "blockingReasons": [
-        "duplicate-title"
-      ],
-      "warningReasons": [
-        "short-summary"
-      ],
-      "summaryChars": 46,
-      "wordCount": 0,
-      "publishDay": "2021-7-2",
-      "lastEditedDay": "2024-4-8",
-      "href": "/article/example-8",
-      "url": "https://preview.tangly1024.com/article/example-8"
-    },
-    {
-      "id": "c4fe8170-c1be-4ed8-a3e5-680d2fa189d6",
-      "slug": "article/example-9",
-      "title": "Blank article",
-      "isIndexBlocked": true,
-      "reasons": [
-        "short-summary",
-        "duplicate-title"
-      ],
-      "blockingReasons": [
-        "duplicate-title"
-      ],
-      "warningReasons": [
-        "short-summary"
-      ],
-      "summaryChars": 46,
-      "wordCount": 0,
-      "publishDay": "2021-7-2",
-      "lastEditedDay": "2024-4-8",
-      "href": "/article/example-9",
-      "url": "https://preview.tangly1024.com/article/example-9"
-    }
-  ]
+  "indexBlockedPosts": []
 }


### PR DESCRIPTION
原因定位到了：这次不是单纯“空白页”，而是 SSR 直接 500。文章里有 Notion 的 header_4 块，旧的 TOC 代码只认识 header / sub_header / sub_sub_header，导致 indentLevel 是 undefined，随后把缩进栈弹空，触发：Cannot destructure property 'actual' of 'prevIndent' as it is undefined

已修复：
  - lib/notion/getPageTableOfContents.js:9：支持 header_N 这类 Notion 标题类型，并跳过未知 header，避免 TOC 生成时崩溃。
  - pages/[prefix]/[slug]/[...suffix].js:23：保留前面针对 fallback 空壳页的修复，找不到文章时返回真正 404，不再渲染空白文章页。

  验证结果：
  - http://127.0.0.1:3000/article/ios-interactive-pop-gesture-conflict-debugging 现在返回 200
  - 页面标题正确：iOS UINavigationController 手势冲突排查：左滑正常，右滑却返回首页 | Joey’s 博客
  - Server Error=false
  - Cannot destructure=false
  - hasArticleContent=true
  - npm run build 已通过；只有已有警告：页面数据过大、Browserslist 过旧、Algolia 配置缺失。

最终工作区只留下两个相关源码文件变更。浏览器插件本身因工具层 sandboxPolicy 报错不可用，所以这次用本地 HTTP 请求和构建结果完成验证。