### PR TITLE
Update min word count for short-body logic and SEO handling

### DIFF
--- a/conf/post.config.js
+++ b/conf/post.config.js
@@ -50,8 +50,10 @@ module.exports = {
     process.env.NEXT_PUBLIC_CONTENT_QUALITY_GUARD ?? 'true',
   CONTENT_MIN_SUMMARY_CHARS:
     process.env.NEXT_PUBLIC_CONTENT_MIN_SUMMARY_CHARS || 80,
+  // 正文字数下限（约等于中文字数）。低于此值的正文在详情页渲染时判定为 short-body，
+  // 触发 noindex。400 对齐人工审计的「极薄」线，自动兜住明显过薄的正文，误伤好文概率低。
   CONTENT_MIN_WORD_COUNT:
-    process.env.NEXT_PUBLIC_CONTENT_MIN_WORD_COUNT || 260,
+    process.env.NEXT_PUBLIC_CONTENT_MIN_WORD_COUNT || 400,
   CONTENT_MIN_SENTENCE_UNIQUE_RATIO:
     process.env.NEXT_PUBLIC_CONTENT_MIN_SENTENCE_UNIQUE_RATIO || 0.6,
   // 质量规则豁免：逗号分隔 slug，仅用于少数必须保留且内容较短的正式页面。

--- a/lib/utils/content-indexing.js
+++ b/lib/utils/content-indexing.js
@@ -126,7 +126,7 @@ function getQualityConfig() {
   return {
     enabled: parseBooleanConfig(BLOG.CONTENT_QUALITY_GUARD, true),
     minSummaryChars: parseNumberConfig(BLOG.CONTENT_MIN_SUMMARY_CHARS, 80),
-    minWordCount: parseNumberConfig(BLOG.CONTENT_MIN_WORD_COUNT, 260),
+    minWordCount: parseNumberConfig(BLOG.CONTENT_MIN_WORD_COUNT, 400),
     minSentenceUniqueRatio: parseNumberConfig(
       BLOG.CONTENT_MIN_SENTENCE_UNIQUE_RATIO,
       0.6


### PR DESCRIPTION
已改（2 个文件）

- conf/post.config.js:53 — CONTENT_MIN_WORD_COUNT 默认 260 → 400，加了注释说明口径
- lib/utils/content-indexing.js:129 — fallback 同步 260 → 400

机制：文章详情页渲染时算正文字数，< 400 → short-body 阻断 → SEO.js 输出 noindex,nofollow。short-body 已在代码默认 blockReasons 里，不用额外改。

你必须核对的两点（我在本地看不到，可能让改动在生产上失效）

生产 Vercel 的环境变量会覆盖代码默认值。报告快照显示的 blockReasons 只有 2 项、minWordCount 是 260，所以：

1. NEXT_PUBLIC_CONTENT_MIN_WORD_COUNT —— 如果 Vercel 上显式设了 260，我的改动无效。要么删掉这个变量（用代码默认 400），要么直接在 Vercel 改成 400。
2. NEXT_PUBLIC_CONTENT_QUALITY_BLOCK_REASONS —— 必须包含 short-body，否则薄正文只报警告、不 noindex。若 Vercel 上是 duplicate-title,repetitive-summary 这种窄集合，加上 short-body。

两个诚实的边界，别误解这次改动

- 只影响文章页自己的 robots meta（这正是 Googlebot/AdSense 爬该 URL 时读的信号，对过审最关键）。sitemap 和文章列表不会自动剔除这些薄文——因为构建时正文没加载，字数拿不到。要让薄文同时退出 sitemap/列表，仍得靠 content-curation.config.js 手工清单。这是架构约束，不是遗漏。
- 验证状态：我只做了逻辑走查，没跑完整 Next 构建来实测某篇 300 字文章翻成 noindex。建议部署后用 curl -A "Mozilla/5.0" https://mufeng.blog/article/<某篇薄文> | grep -i noindex 确认 meta 出现。