### PR TITLE
Remove slugs from content curation and add 301 redirects

### DIFF
--- a/conf/content-curation.config.js
+++ b/conf/content-curation.config.js
@@ -48,10 +48,12 @@ const VERY_THIN_TECH = [
   'remove-app-from-app-store',
   'remove-sensitive-env-files-from-git-history',
   'hfs-http-file-server-lan-share-upload-download-guide',
-  'ios-app-store-distribution-certificate-sha1-public-key',
-  // 下面两篇 slug 与正文不符（slug 漂移），建议改 slug + 扩写，暂先 noindex：
-  'ui-ux-pro-max-ai-design-skill-for-cursor', // 正文实为 StoreKit 测试
-  'cloudflare-pages-and-privacy-policy-for-ios-apps' // 正文实为 Cloudflare Worker 存密钥
+  'ios-app-store-distribution-certificate-sha1-public-key'
+  // 已从此清单移除并恢复收录（2026-07-13）：两篇原 slug 与正文不符，正文均为
+  // 实在的原创技术内容，已在 Notion 改为描述正文的新 slug，旧 slug 的 301 见
+  // next.config.js：
+  //   ui-ux-pro-max-ai-design-skill-for-cursor        → xcode-storekit-configuration-local-iap-testing（StoreKit 本地测试内购）
+  //   cloudflare-pages-and-privacy-policy-for-ios-apps → cloudflare-worker-store-api-keys-secrets-ios（Cloudflare Worker 存密钥）
 ]
 
 // ── D. 单薄技术（400–700 中文字）：建议 noindex，可按需保留 ────────────────

--- a/next.config.js
+++ b/next.config.js
@@ -148,6 +148,21 @@ const nextConfig = {
             source: '/article/prevent-macos-from-sleeping-with-caffeinate',
             destination: '/article/mac-caffeinate-shutdown-poweroff-ai-agent',
             statusCode: 301
+          },
+          // ── slug 漂移修正（2026-07-13）：旧 slug 与正文不符，正文为实在的原创
+          //    技术内容，已改为描述正文的新 slug 并恢复收录；旧 slug 301 到新 slug
+          //    以保留链接权重、避免旧 URL 404。
+          //    ⚠️ 部署前务必先在 Notion 把两篇的 slug 改成下面 destination 的值，
+          //    否则旧 URL 会 301 到尚不存在的新 URL 而 404。
+          {
+            source: '/article/ui-ux-pro-max-ai-design-skill-for-cursor',
+            destination: '/article/xcode-storekit-configuration-local-iap-testing',
+            statusCode: 301
+          },
+          {
+            source: '/article/cloudflare-pages-and-privacy-policy-for-ios-apps',
+            destination: '/article/cloudflare-worker-store-api-keys-secrets-ios',
+            statusCode: 301
           }
           // ── 合并集群（待新长文上线后再启用，目标文章尚未创建）──────────
           // 集群A 代理配置 → 新建《Mac 开发者代理配置完全指南》后启用：


### PR DESCRIPTION
1. conf/content-curation.config.js — 从 VERY_THIN_TECH（即 CONTENT_EXCLUDE_SLUGS）移除这两个 slug，留注释记录去向。移除后新 slug 默认可收录、进 sitemap。

2. next.config.js — 新增两条 301，旧 slug → 新 slug，保留链接权重、避免旧 URL 404。