### PR TITLE
真实遗漏：搜索页 __NEXT_DATA__ 仍带被排除文章（第九节该条不通过）

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -17,6 +17,9 @@ export async function getStaticProps(req) {
   const { locale } = req
 
   const props = (await getGlobalData({ from: '404', locale })) || {}
+  // 退役页（如 /links）以 notFound 落到本页，allPages 未经 isPublishedPostForList
+  // 过滤，留在 props 里会把已排除的页面序列化进 __NEXT_DATA__。
+  delete props.allPages
   return { props }
 }
 

--- a/pages/search/[keyword]/index.js
+++ b/pages/search/[keyword]/index.js
@@ -38,6 +38,9 @@ export async function getServerSideProps({ params: { keyword }, locale }) {
     props.posts = props.posts?.slice(0, POSTS_PER_PAGE)
   }
   props.keyword = keyword
+  // allPages 未经 isPublishedPostForList 过滤，留在 props 里会把被排除的薄文
+  // 序列化进 __NEXT_DATA__。与 pages/index.js、[keyword]/page/[page].js 保持一致。
+  delete props.allPages
   return { props }
 }
 

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -46,6 +46,9 @@ export async function getStaticProps({ locale }) {
   })
   const { allPages } = props
   props.posts = allPages?.filter(isPublishedPostForList)
+  // allPages 未经 isPublishedPostForList 过滤，留在 props 里会把被排除的薄文
+  // 序列化进 __NEXT_DATA__。与 pages/index.js 保持一致。
+  delete props.allPages
   return {
     props,
     revalidate: process.env.EXPORT

--- a/public/content-quality-report.json
+++ b/public/content-quality-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-30T12:07:02.444Z",
+  "generatedAt": "2026-07-31T10:48:15.650Z",
   "site": "https://mufeng.blog",
   "qualityGuard": {
     "enabled": true,


### PR DESCRIPTION
/search/claude-code 的 HTML 中 claude-code-shortcuts-... 出现 2 次， 位置均在 __NEXT_DATA__ 内（偏移 140102 / 140930，NEXT_DATA 起点 24842） 渲染层 href="/article/claude-code-shortcuts-..." 出现次数：0

根因：pages/index.js:77 有 delete props.allPages，而 pages/search/[keyword]/index.js 没有——props.posts 已按 isPublishedPostForList 过滤（第 24 行），但未过滤的 allPages 整包留在 props 里被序列化。/links 的 404 页面同理，源码里能搜到 {"slug":"links","title":"友链"}。

风险评估：搜索页和 404 页本身都是 noindex, follow，且没有渲染出可点链接，对 AdSense 和索引都不构成阻断。属于「清单条目不通过但不阻塞」。

改动是给 pages/search/[keyword]/index.js、[keyword]/page/[page].js、search/index.js 补 delete props.allPages。