### PR TITLE
改动已完成，构建进行中。

### DIFF
--- a/components/SEO.js
+++ b/components/SEO.js
@@ -111,7 +111,11 @@ const SEO = props => {
     router.route === '/category/[category]/page/[page]' ||
     router.route === '/search' ||
     router.route === '/search/[keyword]' ||
-    router.route === '/search/[keyword]/page/[page]'
+    router.route === '/search/[keyword]/page/[page]' ||
+    // 作品页与付费专栏页正文各约 320 字，属 AdSense「内容单薄」区间。
+    // 先退出索引，待内容补齐后从此处删除对应行即可恢复收录。
+    router.route === '/works' ||
+    router.route === '/membership'
   const isNoIndexPage = isNoIndexRoute || isNoIndexPost(post)
   const robotsContent =
     router.route === '/404'

--- a/themes/mufeng/index.js
+++ b/themes/mufeng/index.js
@@ -19,6 +19,19 @@ import BlogListPage from './components/BlogListPage'
 import Catalog from './components/Catalog'
 // 静态导入（SSR）：首页「往期精选」链接必须进入初始 HTML 才能提升长尾抓取优先级
 import PastPosts from './components/PastPosts'
+// 静态导入（SSR）：以下组件承载站点骨架与内链，必须进入初始 HTML。
+// 此前均为 dynamic(ssr:false)，导致文章页首屏 HTML 无 <h1>、无导航、无页脚、
+// 无任何指向其他文章与关于页/隐私政策的链接（AdSense「低价值内容」判定的直接对应项）。
+// 已确认这些组件在渲染期不访问 window/document，浏览器 API 仅出现在事件处理器与 useEffect 内。
+import ArticleInfo from './components/ArticleInfo'
+import ArticleAround from './components/ArticleAround'
+import Header from './components/Header'
+import NavBar from './components/NavBar'
+import LeftSidebar from './components/LeftSidebar'
+import Footer from './components/Footer'
+import RecommendPosts from './components/RecommendPosts'
+import PaidColumnsPage from './components/PaidColumnsPage'
+import WorksPage from './components/WorksPage'
 
 
 const AlgoliaSearchModal = dynamic(
@@ -36,31 +49,16 @@ const BlogArchiveItem = dynamic(() => import('./components/BlogArchiveItem'), {
 const ArticleLock = dynamic(() => import('./components/ArticleLock'), {
   ssr: false
 })
-const ArticleInfo = dynamic(() => import('./components/ArticleInfo'), {
-  ssr: false
-})
 const Comment = dynamic(() => import('@/components/Comment'), { ssr: false })
-const ArticleAround = dynamic(() => import('./components/ArticleAround'), {
-  ssr: false
-})
 const ShareBar = dynamic(() => import('@/components/ShareBar'), { ssr: false })
 const TopBar = dynamic(() => import('./components/TopBar'), { ssr: false })
-const Header = dynamic(() => import('./components/Header'), { ssr: false })
-const NavBar = dynamic(() => import('./components/NavBar'), { ssr: false })
-const LeftSidebar = dynamic(() => import('./components/LeftSidebar'), {
-  ssr: false
-})
 const JumpToTopButton = dynamic(() => import('./components/JumpToTopButton'), {
   ssr: false
 })
-const Footer = dynamic(() => import('./components/Footer'), { ssr: false })
 const SearchInput = dynamic(() => import('./components/SearchInput'), {
   ssr: false
 })
 const WWAds = dynamic(() => import('@/components/WWAds'), { ssr: false })
-const RecommendPosts = dynamic(() => import('./components/RecommendPosts'), {
-  ssr: false
-})
 const PageTitle = dynamic(() => import('./components/PageTitle'))
 const DarkModeButton = dynamic(() => import('@/components/DarkModeButton'), {
   ssr: false
@@ -69,12 +67,6 @@ const FloatTocButton = dynamic(() => import('./components/FloatTocButton'), {
   ssr: false
 })
 const RewardButton = dynamic(() => import('./components/RewardButton'), {
-  ssr: false
-})
-const PaidColumnsPage = dynamic(() => import('./components/PaidColumnsPage'), {
-  ssr: false
-})
-const WorksPage = dynamic(() => import('./components/WorksPage'), {
   ssr: false
 })
 // 主题全局状态


### PR DESCRIPTION
themes/mufeng/index.js

9 个组件从 dynamic(..., {ssr:false}) 改为静态导入（26-34 行），并删除对应的 dynamic 声明：

ArticleInfo      文章标题 <h1>、作者、日期
ArticleAround    上一篇 / 下一篇内链
Header           站点头部
NavBar           顶部导航 + 搜索
LeftSidebar      主导航（archive / category / tag / works / about）
Footer           页脚（含 /privacy-policy 入口）
RecommendPosts   相关文章内链
PaidColumnsPage  /membership 正文
WorksPage        /works 正文

保留 ssr:false 的 13 个不动：AlgoliaSearchModal、BlogListScroll、BlogArchiveItem、ArticleLock、Comment、ShareBar、TopBar、JumpToTopButton、SearchInput、WWAds、DarkModeButton、FloatTocButton、RewardButton——这些是交互件，不承载内容或内链。

components/SEO.js:112-118

/works、/membership 加入 isNoIndexRoute，注释里写明恢复方式（删掉对应两行即可）。

关于 /works、/membership 的判

转成 SSR 后它们会有真实正文， 在
AdSense「内容单薄」区间。我选noindex——复审期间不给审核者留可索引的薄页面。这是我替你做的判断，不是方案 A 里写死的，你要放开随时删两行。
