### PR TITLE
改动（两处，都只保留完整路径匹配）：

### DIFF
--- a/pages/[prefix]/[slug]/[...suffix].js
+++ b/pages/[prefix]/[slug]/[...suffix].js
@@ -68,20 +68,19 @@ export async function getStaticProps({
 
   const suffixPath = suffixSegments.join('/')
   const tailSlug = slug + '/' + suffixPath
-  const lastSlugSegment = suffixSegments[suffixSegments.length - 1]
   const fullSlug = prefix + '/' + tailSlug
   const from = `slug-props-${fullSlug}`
   const props = await getGlobalData({ from, locale })
 
-  // 在列表内查找文章
+  // 在列表内查找文章。
+  // 只按完整路径匹配：此前还允许 tailSlug / suffixPath / lastSlugSegment 三种
+  // 忽略 prefix 的尾段匹配，导致 /<任意前缀>/article/<slug> 都能以 200 + index,follow
+  // 返回同一篇文章（实测 /en、/zzz、/fr 均命中），构成无上界的重复内容 URL 空间。
+  // 站内真实数据中不存在三段及以上的 slug，因此去掉这三个分支不影响正常 URL。
   props.post = props?.allPages?.find(p => {
     return (
       (p.type || '').indexOf('Menu') < 0 &&
-      (p.slug === tailSlug ||
-        p.slug === suffixPath ||
-        p.slug === lastSlugSegment ||
-        p.slug === fullSlug ||
-        p.id === idToUuid(fullSlug))
+      (p.slug === fullSlug || p.id === idToUuid(fullSlug))
     )
   })
 

--- a/pages/[prefix]/[slug]/index.js
+++ b/pages/[prefix]/[slug]/index.js
@@ -70,11 +70,16 @@ export async function getStaticProps({ params: { prefix, slug }, locale }) {
   const from = `slug-props-${fullSlug}`
   const props = await getGlobalData({ from, locale })
 
-  // 在列表内查找文章
+  // 在列表内查找文章。
+  // 只按完整路径匹配：此前还允许 `p.slug === slug`（忽略 prefix 的裸 slug 匹配），
+  // 导致任意前缀都能命中同一篇内容——例如 /xx/privacy-policy 会以 200 + index,follow
+  // 返回隐私政策正文，构成无上界的重复内容 URL 空间。
+  // 站内真实数据中所有 Post 的 slug 均为两段（article/xxx），裸 slug 的 Page
+  // 由 pages/[prefix]/index.js 在单段路径上提供服务，因此去掉该分支不影响正常 URL。
   props.post = props?.allPages?.find(p => {
     return (
       (p.type || '').indexOf('Menu') < 0 &&
-      (p.slug === slug || p.slug === fullSlug || p.id === idToUuid(fullSlug))
+      (p.slug === fullSlug || p.id === idToUuid(fullSlug))
     )
   })
 

--- a/public/content-quality-report.json
+++ b/public/content-quality-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-01T09:58:43.577Z",
+  "generatedAt": "2026-08-01T10:34:49.921Z",
   "site": "https://mufeng.blog",
   "qualityGuard": {
     "enabled": true,


### PR DESCRIPTION
// pages/[prefix]/[slug]/index.js:74-85
-  (p.slug === slug || p.slug === fullSlug || p.id === idToUuid(fullSlug))
+  (p.slug === fullSlug || p.id === idToUuid(fullSlug))

// pages/[prefix]/[slug]/[...suffix].js:76-86
-  (p.slug === tailSlug || p.slug === suffixPath ||
-   p.slug === lastSlugSegment || p.slug === fullSlug ||
-   p.id === idToUuid(fullSlug))
+  (p.slug === fullSlug || p.id === idToUuid(fullSlug))

顺带删掉了因此变成未使用变量的 lastSlugSegment（原 71 行）。

改之前核对的数据依据：

allNavPages 总数: 173
按 slug 段数统计: {"2":
1 段 slug: 无
3 段及以上 slug: 无

全部 Post 都是 article/lSlug 完全覆盖。裸 slug的 privacy-policy 是 Page，由 pages/[prefix]/index.js 在单段路径提供服务，不 emap 里也只有 1 段（2
条）和 2 段（172 条），

构建完的回归测试计划：
正常必须仍是 200 —— sit篇文章逐条测、/privacy-异常必须变 404 —— /en/ae/<slug>、/fr/article/<slug>、/xx/privacy-polic

172 篇全量跑是为了确认没有误杀，只测几篇不足以证明。结果出来我把两边的原始数字都贴给你。

在回归通过之前，这个改动不能算完成——路由匹配收紧是这次所有改动里破坏面最大的一个。
