### PR TITLE
移除 LayoutBase 入场动画的 appear，修复首屏内容需等 hydration 才可见

### DIFF
--- a/themes/mufeng/index.js
+++ b/themes/mufeng/index.js
@@ -134,7 +134,6 @@ const LayoutBase = props => {
 
                 <Transition
                   show={!onLoading}
-                  appear={true}
                   enter='transition ease-in-out duration-500 transform order-first'
                   enterFrom='opacity-0 translate-y-8'
                   enterTo='opacity-100'


### PR DESCRIPTION
Transition 同时设置了 appear={true} 与 enterFrom='opacity-0 translate-y-8'， 导致服务端就把整个内容区渲染成 opacity: 0——线上 HTML 实测：

  <div class="transition ... opacity-0 translate-y-8">
    <div class="relative"><div class="xl:max-w-4xl 2xl:max-w-6xl">
      <section>...</section>              ← ArticleInfo
      <div id="article-wrapper"><div id="notion-article">  ← 正文

内容在 DOM 里（爬虫读得到，SSR 整改结论不受影响），但视觉上不可见，
必须等 React hydration 完成、Transition 在客户端跑完 appear 动画才显现。

Lighthouse trace（移动端，Rocket Loader 已关）实测时间线：
  3517ms  FCP，但 LCP 候选是一个 817px² 的导航项，屏幕基本空白
  5560ms  Next.js-before-hydration
  5710ms  afterHydrate（hydration 本身仅 150ms，不是瓶颈）
  6350ms  LCP 候选才变为正文（50416px²）
截图胶片印证：3.3s 纯白，4.9s 只有页头，6.6s 才有完整内容。
禁用 JS 时正文永不出现，LCP 元素退化为导航栏的 MENU 按钮。

appear 只影响首次挂载；show 由 onLoading 在 routeChangeStart/Complete 切换（lib/global.js:142-151），路由切换的淡入动画不受影响。

验证：本地 dev 三个页面 opacity-0 计数 1 → 0，nav/footer/h1/内链数不变； hydration 无报错；点击站内链接路由跳转正常、切换后 opacity 为 1。
