### PR TITLE
feat: Enable Google Analytics tracking only in production environment

### DIFF
--- a/components/ExternalPlugins.js
+++ b/components/ExternalPlugins.js
@@ -91,6 +91,10 @@ const ExternalPlugin = props => {
     null,
     NOTION_CONFIG
   )
+  // 谷歌统计只在生产环境上报：本地 dev 用的是同一个 measurement ID，
+  // 不加门禁会把开发时的反复刷新混进 GA4 数据里。
+  const GTAG_ENABLED =
+    !!ANALYTICS_GOOGLE_ID && process.env.NODE_ENV === 'production'
   const MATOMO_HOST_URL = siteConfig('MATOMO_HOST_URL', null, NOTION_CONFIG)
   const MATOMO_SITE_ID = siteConfig('MATOMO_SITE_ID', null, NOTION_CONFIG)
   const ANALYTICS_51LA_ID = siteConfig('ANALYTICS_51LA_ID', null, NOTION_CONFIG)
@@ -185,7 +189,7 @@ const ExternalPlugin = props => {
       {THEME_SWITCH && <ThemeSwitch />}
       {DEBUG && <DebugPanel />}
       {ANALYTICS_ACKEE_TRACKER && <Ackee />}
-      {ANALYTICS_GOOGLE_ID && <Gtag />}
+      {GTAG_ENABLED && <Gtag />}
       {ANALYTICS_VERCEL && <Analytics />}
       {ANALYTICS_BUSUANZI_ENABLE && <Busuanzi />}
       {FACEBOOK_APP_ID && FACEBOOK_PAGE_ID && <Messenger />}
@@ -387,7 +391,7 @@ const ExternalPlugin = props => {
       )}
 
       {/* 谷歌统计 */}
-      {ANALYTICS_GOOGLE_ID && (
+      {GTAG_ENABLED && (
         <>
           <script
             async

--- a/public/content-quality-report.json
+++ b/public/content-quality-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-05T10:33:36.394Z",
+  "generatedAt": "2026-08-07T08:00:38.766Z",
   "site": "https://mufeng.blog",
   "qualityGuard": {
     "enabled": true,
@@ -16,15 +16,15 @@
     ]
   },
   "totals": {
-    "publishedPosts": 205,
+    "publishedPosts": 208,
     "lowQualityPosts": 5,
     "indexBlockedPosts": 0,
     "warningOnlyPosts": 5,
     "curationExcludedPosts": 32,
-    "indexablePosts": 173,
+    "indexablePosts": 176,
     "nonIndexablePosts": 32,
     "postsWithBodyMetrics": 0,
-    "postsMissingBodyMetrics": 205
+    "postsMissingBodyMetrics": 208
   },
   "reasonStats": {
     "all": {
@@ -35,7 +35,7 @@
       "short-summary": 5
     },
     "audit": {
-      "missing-body-metrics": 205
+      "missing-body-metrics": 208
     }
   },
   "lowQualityPosts": [


### PR DESCRIPTION
Added a conditional check to enable Google Analytics tracking based on the environment, ensuring that development data does not interfere with production analytics. Updated the content quality report with new published post metrics and adjusted the generated timestamp.
